### PR TITLE
Add isort

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,3 @@
-default_language_version:
-  python: python3.8
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.1.0
@@ -14,7 +12,11 @@ repos:
     hooks:
       - id: pyupgrade
         language: python
-        args: [--py36-plus]
+        args: [--py37-plus]
+  - repo: https://github.com/pycqa/isort
+    rev: 5.10.1
+    hooks:
+      - id: isort
   - repo: https://github.com/ambv/black
     rev: 22.1.0
     hooks:
@@ -27,7 +29,6 @@ repos:
         language: python
         additional_dependencies:
           - flake8-bugbear
-          - flake8-import-order
           - pep8-naming
           # The following is disabled due to a runtime error
           # - flake8-docstrings

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,11 @@ chardet = "*"
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
+[tool.isort]
+profile = "black"
+known_first_party = ["pyswot", "tests"]
+line_length = 79
+
 [tool.black]
 line-length = 79
 target-version = ['py37']

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,10 +3,6 @@ python_version = 3.7
 
 [flake8]
 max-line-length = 79
-application-import-names =
-    tests
-    pyswot
-import-order-style = pycharm
 docstring-convention = numpy
 max-complexity = 10
 select =
@@ -41,5 +37,3 @@ ignore =
     W503
 per-file-ignores =
     pyswot/vendor/domains.py:B950
-    pyswot/vendor/stoplist.py:B950
-    pyswot/vendor/tlds.py:B950


### PR DESCRIPTION
This PR adds isort with the following changes:

- [x] `default_language_version` removed
- [x] pyupgrade args set correctly
- [x] `isort` added before `black`
- [x] `flake8-import-order` removed
- [x] `known_first_party` set correctly
- [x] `application-import-names` and `import-order-style` removed