### PR TITLE
Improve import time

### DIFF
--- a/pyswot/pyswot.py
+++ b/pyswot/pyswot.py
@@ -1,9 +1,5 @@
 from typing import FrozenSet, List
 
-from pyswot.vendor.domains import DOMAINS
-from pyswot.vendor.stoplist import STOPLIST
-from pyswot.vendor.tlds import TLDS
-
 
 def is_academic(email: str) -> bool:
     parts = _domain_parts(email)
@@ -17,14 +13,20 @@ def find_school_names(email: str) -> List[str]:
 
 
 def _is_under_tld(parts: List[str]) -> bool:
+    from pyswot.vendor.tlds import TLDS
+
     return _check_set(TLDS, parts)
 
 
 def _is_stoplisted(parts: List[str]) -> bool:
+    from pyswot.vendor.stoplist import STOPLIST
+
     return _check_set(STOPLIST, parts)
 
 
 def _find_school_names(parts: List[str]) -> List[str]:
+    from pyswot.vendor.domains import DOMAINS
+
     key = ""
     for part in parts:
         key = f".{part}{key}"


### PR DESCRIPTION
Cut the import time by ~10ms by deferring the import of the `DOMAINS`, `TLDS` and `STOPLIST`. This will add the 10ms to the first call of the method but will not affect subsequent calls. Inspired by https://adamj.eu/tech/2023/03/02/django-profile-and-improve-import-time/.

Main (note that timings are a factor 1000 higher in the display, so 1s on the graph is 1ms in reality):

![image](https://user-images.githubusercontent.com/12661555/223687935-b4305e94-0dfa-4901-8a6c-ad4fda539b8a.png)

This branch:

![image](https://user-images.githubusercontent.com/12661555/223687797-7a7dcd5d-aba9-4a0c-bd7c-74b7bb68c849.png)

Runtime unaffected:

```
pyswot version: 0.3.0
10000 loops for user@gmcc.tnua.edu.tw, best of 5: 6.785823900027026e-06 s
10000 loops for user@nope.tnua.edu.tw, best of 5: 5.781288719990698e-06 s
```